### PR TITLE
Add local testing infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .build
+.perl-version
+cpanfile.snapshot
+local/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+Contributing to BZ::Client
+==========================
+
+## Getting Started
+
+If you have carton available you should just be able to
+clone this repo, change to the directory, and run `make test`.
+
+### Installing dependencies
+
+The dependencies for this project are listed in its `cpanfile`,
+this file is usually handled by [Carton](https://metacpan.org/pod/Carton).
+
+Installing Carton can be done with any CPAN client into whichever version of perl you want to use.
+
+If you don't have permission, or just don't want to install things into your system perl, you can use [App::Plenv](https://github.com/tokuhirom/plenv) and the [perl-build](https://github.com/tokuhirom/perl-build) plugin, or [Perlbrew](https://perlbrew.pl/) to install different versions of perl.
+
+Once you have a version of perl to use for testing this, if you don't have a preference for a CPAN client, we recommend you use [cpanminus](https://metacpan.org/pod/App::cpanminus#Installing-to-system-perl).
+
+With `plenv` you are able to get cpanminus with `plenv install-cpanm`.
+
+Otherwise, quoting the cpanminus quickstart instructions:
+
+> Quickstart: Run the following command and it will install itself for you.
+> You might want to run it as a root with sudo if you want to
+> install to places like /usr/local/bin.
+>
+>   `% curl -L https://cpanmin.us | perl - App::cpanminus`
+>
+> If you don't have curl but wget, replace `curl -L` with `wget -O -`.
+
+Once you have cpanminus, you can install Carton with:
+
+    cpanm Carton
+
+With `carton` available, you can run `make test` and make sure tests pass.  If they do, you're ready to start making changes and get ready to create a Pull Request.
+
+### Using Dist::Zilla
+
+The release of this distribution is managed by [Dist::Zilla](http://dzil.org) which provides a lot of benefits for managing releases and modules at the expense of longer a learning curve.
+
+However, you probably don't need it unless you want to build a release or run author tests.
+
+In order to work with Dist::Zilla's `dzil` you will need to run `carton install` manually as the Makefile uses `--without develop` to avoid unnecessary dependencies.
+
+Once those dependencies are installed, you need to use `carton exec dzil` so it can find them.
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,63 @@
+# This is based on the version in Dist::Zilla::PluginBundle::Author::GSG
+# See the docmentation for that module for details.
+
+DIST_NAME   ?= $(shell perl -ne '/^\s*name\s*=\s*(\S+)/ && print $$1' dist.ini )
+MAIN_MODULE ?= $(shell perl -ne '/^\s*main_module\s*=\s*(\S+)/ && print $$1' dist.ini )
+
+CARTON            ?= $(shell which carton 2>/dev/null || echo carton )
+CPANFILE_SNAPSHOT ?= $(shell \
+  carton exec perl -MFile::Spec -e \
+	'($$_) = grep { -e } map{ "$$_/../../cpanfile.snapshot" } \
+		grep { m(/lib/perl5$$) } @INC; \
+		print File::Spec->abs2rel($$_) . "\n" if $$_' 2>/dev/null )
+
+ON_DEVELOP := $(shell $(CARTON) exec -- \
+	dzil nop >/dev/null 2>/dev/null && echo $(CARTON) || echo develop )
+
+ifeq ($(MAIN_MODULE),)
+MAIN_MODULE := lib/$(subst -,/,$(DIST_NAME)).pm
+endif
+ifeq ($(CPANFILE_SNAPSHOT),)
+CPANFILE_SNAPSHOT    := cpanfile.snapshot
+endif
+CARTON_INSTALL_FLAGS ?= --without develop
+PERL_CARTON_PERL5LIB ?= $(PERL5LIB)
+
+.PHONY : test clean realclean develop carton
+
+test : $(CPANFILE_SNAPSHOT)
+	@nice $(CARTON) exec prove -lfr t
+
+# This target requires that you add 'requires "Devel::Cover";'
+# to the cpanfile and then run "carton" to install it.
+testcoverage : $(CPANFILE_SNAPSHOT)
+	$(CARTON) exec -- cover -test -ignore . -select ^lib
+
+clean:
+	$(CARTON) exec dzil clean || true
+	rm -rf .build
+
+realclean: clean
+	rm -rf local
+
+# If dzil run can provide these items with different Plugins,
+# we could update the repo with new versions by running make update.
+#
+#update: README.md LICENSE.txt
+#	@echo Everything is up to date
+#
+#README.md: $(MAIN_MODULE) dist.ini $(ON_DEVELOP)
+#	$(CARTON) exec dzil run sh -c "pod2markdown $< > ${CURDIR}/$@"
+#
+#LICENSE.txt: dist.ini $(ON_DEVELOP)
+#	$(CARTON) exec dzil run sh -c "install -m 644 LICENSE ${CURDIR}/$@"
+
+$(CPANFILE_SNAPSHOT): $(CARTON) cpanfile
+	$(CARTON) install $(CARTON_INSTALL_FLAGS)
+
+develop: $(CPANFILE_SNAPSHOT)
+	$(CARTON) install # with develop
+
+carton:
+	@echo You must install carton: https://metacpan.org/pod/Carton >&2;
+	@false;

--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,57 @@
+requires "perl", "5.8.0";
+requires "strict";
+requires "warnings";
+requires "parent";
+
+requires "XML::Parser";
+requires "XML::Writer";
+requires "HTTP::CookieJar";
+requires "HTTP::Tiny";
+requires "File::Basename";
+requires "File::Spec";
+requires "Encode";
+requires "URI";
+requires "DateTime::TimeZone";
+requires "DateTime::Format::Strptime";
+requires "DateTime::Format::ISO8601";
+requires "MIME::Base64";
+
+on test => sub {
+	requires "IO::Socket::SSL";
+	requires "Test::More";
+	requires "Test::RequiresInternet";
+	requires "DateTime";
+	requires "Text::Password::Pronounceable";
+	requires "Data::Dumper";
+	requires "Clone";
+};
+
+on develop => sub {
+	requires "Dist::Zilla::PluginBundle::Basic";
+
+	requires "Dist::Zilla::Plugin::Prereqs::FromCPANFile";
+	requires "Dist::Zilla::Plugin::GithubMeta";
+	requires "Dist::Zilla::Plugin::MetaJSON";
+	requires "Dist::Zilla::Plugin::MetaTests";
+	requires "Dist::Zilla::Plugin::ModuleBuild";
+	requires "Dist::Zilla::Plugin::TravisYML";
+	requires "Dist::Zilla::Plugin::Covenant";
+	requires "Dist::Zilla::Plugin::Test::Perl::Critic";
+	requires "Dist::Zilla::Plugin::Test::Kwalitee";
+	requires "Dist::Zilla::Plugin::Test::EOF";
+	requires "Dist::Zilla::Plugin::Test::EOL";
+	requires "Dist::Zilla::Plugin::Test::NoTabs";
+	requires "Dist::Zilla::Plugin::Test::Portability";
+	requires "Dist::Zilla::Plugin::Test::ReportPrereqs";
+	requires "Dist::Zilla::Plugin::Test::NoBreakpoints";
+	requires "Dist::Zilla::Plugin::Test::UnusedVars";
+	requires "Dist::Zilla::Plugin::PodSyntaxTests";
+	requires "Dist::Zilla::Plugin::RunExtraTests";
+	requires "Dist::Zilla::Plugin::PkgVersion";
+	requires "Dist::Zilla::Plugin::PodWeaver";
+	requires "Dist::Zilla::Plugin::Git::Remote::Check";
+	requires "Dist::Zilla::Plugin::Git::Tag";
+	requires "Dist::Zilla::Plugin::PruneCruft";
+	requires "Dist::Zilla::Plugin::Clean";
+	requires "Dist::Zilla::Plugin::Prereqs";
+};

--- a/cpanfile
+++ b/cpanfile
@@ -50,6 +50,7 @@ on develop => sub {
 	requires "Dist::Zilla::Plugin::PkgVersion";
 	requires "Dist::Zilla::Plugin::PodWeaver";
 	requires "Dist::Zilla::Plugin::Git::Remote::Check";
+	requires "Dist::Zilla::Plugin::Git::GatherDir";
 	requires "Dist::Zilla::Plugin::Git::Tag";
 	requires "Dist::Zilla::Plugin::PruneCruft";
 	requires "Dist::Zilla::Plugin::Clean";

--- a/cpanfile
+++ b/cpanfile
@@ -54,4 +54,11 @@ on develop => sub {
 	requires "Dist::Zilla::Plugin::PruneCruft";
 	requires "Dist::Zilla::Plugin::Clean";
 	requires "Dist::Zilla::Plugin::Prereqs";
+
+	# Author test depends
+	requires "Test::CPAN::Meta";
+	requires "Test::EOL";
+	requires "Test::Kwalitee";
+	requires "Test::NoTabs";
+	requires "Test::Pod";
 };

--- a/dist.ini
+++ b/dist.ini
@@ -10,7 +10,6 @@ main_module = lib/BZ/Client.pm
 [@Basic]
 
 ; Stuff that generates files
-[CPANFile]
 [GithubMeta]
 [MetaJSON]
 [MetaTests]
@@ -55,29 +54,4 @@ except = ^\.travis.yml
 
 [Clean]
 
-[Prereqs]
-XML::Parser = 0
-XML::Writer = 0
-HTTP::CookieJar = 0
-HTTP::Tiny = 0
-File::Basename = 0
-File::Spec = 0
-Encode = 0
-URI = 0
-DateTime::TimeZone = 0
-DateTime::Format::Strptime = 0
-DateTime::Format::ISO8601 = 0
-MIME::Base64 = 0
-strict       = 0
-warnings     = 0
-parent       = 0
-perl         = 5.8.0
-
-[Prereqs / TestRequires]
-IO::Socket::SSL = 0
-Test::More = 0
-Test::RequiresInternet = 0
-DateTime = 0
-Text::Password::Pronounceable = 0
-Data::Dumper = 0
-Clone = 0
+[Prereqs::FromCPANfile]

--- a/dist.ini
+++ b/dist.ini
@@ -7,7 +7,9 @@ copyright_holder = Dean Hamstad
 copyright_year = 2017
 main_module = lib/BZ/Client.pm
 
-[@Basic]
+[@Filter]
+-bundle = @Basic
+-remove = GatherDir
 
 ; Stuff that generates files
 [GithubMeta]
@@ -45,6 +47,7 @@ critic_config = t/.perlcriticrc
 
 ; Stuff that plays with Git
 ;[Git::CheckFor::CorrectBranch] ; ensure on master branch
+[Git::GatherDir]
 [Git::Remote::Check]
 [Git::Tag]
 

--- a/t/100bugzilla.t
+++ b/t/100bugzilla.t
@@ -1,8 +1,8 @@
 #!/usr/bin/env perl
 # vim: softtabstop=4 tabstop=4 shiftwidth=4 ft=perl expandtab smarttab
 BEGIN {
-    unless ($ENV{TEST_AUTHOR}) {
-        print qq{1..0 # SKIP these tests only run with TEST_AUTHOR set\n};
+    unless ($ENV{AUTHOR_TESTING}) {
+        print qq{1..0 # SKIP these tests only run with AUTHOR_TESTING set\n};
         exit
     }
 }

--- a/t/101login.t
+++ b/t/101login.t
@@ -2,8 +2,8 @@
 # vim: softtabstop=4 tabstop=4 shiftwidth=4 ft=perl expandtab smarttab
 #
  BEGIN {
-    unless ($ENV{TEST_AUTHOR}) {
-        print qq{1..0 # SKIP these tests only run with TEST_AUTHOR set\n};
+    unless ($ENV{AUTHOR_TESTING}) {
+        print qq{1..0 # SKIP these tests only run with AUTHOR_TESTING set\n};
         exit
     }
 }

--- a/t/200bug.t
+++ b/t/200bug.t
@@ -1,8 +1,8 @@
 #!/usr/bin/env perl
 # vim: softtabstop=4 tabstop=4 shiftwidth=4 ft=perl expandtab smarttab
 BEGIN {
-    unless ($ENV{TEST_AUTHOR}) {
-        print qq{1..0 # SKIP these tests only run with TEST_AUTHOR set\n};
+    unless ($ENV{AUTHOR_TESTING}) {
+        print qq{1..0 # SKIP these tests only run with AUTHOR_TESTING set\n};
         exit
     }
 }

--- a/t/300classification.t
+++ b/t/300classification.t
@@ -1,8 +1,8 @@
 #!/usr/bin/env perl
 # vim: softtabstop=4 tabstop=4 shiftwidth=4 ft=perl expandtab smarttab
 BEGIN {
-    unless ($ENV{TEST_AUTHOR}) {
-        print qq{1..0 # SKIP these tests only run with TEST_AUTHOR set\n};
+    unless ($ENV{AUTHOR_TESTING}) {
+        print qq{1..0 # SKIP these tests only run with AUTHOR_TESTING set\n};
         exit
     }
 }

--- a/t/400component.t
+++ b/t/400component.t
@@ -1,8 +1,8 @@
 #!/usr/bin/env perl
 # vim: softtabstop=4 tabstop=4 shiftwidth=4 ft=perl expandtab smarttab
 BEGIN {
-    unless ($ENV{TEST_AUTHOR}) {
-        print qq{1..0 # SKIP these tests only run with TEST_AUTHOR set\n};
+    unless ($ENV{AUTHOR_TESTING}) {
+        print qq{1..0 # SKIP these tests only run with AUTHOR_TESTING set\n};
         exit
     }
 }

--- a/t/500group.t
+++ b/t/500group.t
@@ -1,8 +1,8 @@
 #!/usr/bin/env perl
 # vim: softtabstop=4 tabstop=4 shiftwidth=4 ft=perl expandtab smarttab
 BEGIN {
-    unless ($ENV{TEST_AUTHOR}) {
-        print qq{1..0 # SKIP these tests only run with TEST_AUTHOR set\n};
+    unless ($ENV{AUTHOR_TESTING}) {
+        print qq{1..0 # SKIP these tests only run with AUTHOR_TESTING set\n};
         exit
     }
 }

--- a/t/600product.t
+++ b/t/600product.t
@@ -1,8 +1,8 @@
 #!/usr/bin/env perl
 # vim: softtabstop=4 tabstop=4 shiftwidth=4 ft=perl expandtab smarttab
 BEGIN {
-    unless ($ENV{TEST_AUTHOR}) {
-        print qq{1..0 # SKIP these tests only run with TEST_AUTHOR set\n};
+    unless ($ENV{AUTHOR_TESTING}) {
+        print qq{1..0 # SKIP these tests only run with AUTHOR_TESTING set\n};
         exit
     }
 }

--- a/t/700user.t
+++ b/t/700user.t
@@ -1,8 +1,8 @@
 #!/usr/bin/env perl
 # vim: softtabstop=4 tabstop=4 shiftwidth=4 ft=perl expandtab smarttab
 BEGIN {
-    unless ($ENV{TEST_AUTHOR}) {
-        print qq{1..0 # SKIP these tests only run with TEST_AUTHOR set\n};
+    unless ($ENV{AUTHOR_TESTING}) {
+        print qq{1..0 # SKIP these tests only run with AUTHOR_TESTING set\n};
         exit
     }
 }


### PR DESCRIPTION
I got here from the pullrequest.club but didn't find any open issues for this project, so thought I could help other folks get started.

This is mostly a copy of what I did for the open source stuff at work, slightly modified because you don't actually use our PluginBundle. The main feature I like is that you don't have to install the heavy Dist::Zilla dependencies to contribute.  It helps some, saving over 10M of space in my local/ dir. It also means you can run `make test` if you have Carton available and it should install the necessary dependencies and run the tests.

I did also switch the GatherDir Plugin you're using because with a `local/` dir it is far too slow for me to run.

I did notice that the perl critic tests seem to fail at the moment, not sure if it's missing a config file for that.